### PR TITLE
docs(datepicker): fix typos in datepicker demo

### DIFF
--- a/demo/src/app/components/+datepicker/datepicker-section.list.ts
+++ b/demo/src/app/components/+datepicker/datepicker-section.list.ts
@@ -38,7 +38,7 @@ export const demoComponentContent: ContentSection[] = [
         html: require('!!raw-loader?lang=markup!./demos/bs-popup/date-picker-popup.html'),
         description: `
           <p><code>BsDatepickerModule</code> is activily developed but you can use it already</p>
-          <p>Notebale change is additional css for it <code> "/datepicker/bs-datepicker.css"</code> <br></p>
+          <p>Noteable change is additional css for it <code> "/datepicker/bs-datepicker.css"</code> <br></p>
           <p>There are two ways of adding css:</p>
           <ul>
             <li>Load it from CDN. Add <code>&lt;link rel="stylesheet"
@@ -77,8 +77,8 @@ export const demoComponentContent: ContentSection[] = [
           define it in your <code>@NgModule</code> using function <code>defineLocale</code></p>
           <p>Example: </p>
           <code>import { defineLocale } from 'ngx-bootstrap/chronos';</code><br>
-          <code>import { de } from 'ngx-bootstrap/locale';</code><br>
-          <code>defineLocale('de', de);</code>
+          <code>import { deLocale } from 'ngx-bootstrap/locale';</code><br>
+          <code>defineLocale('de', deLocale);</code>
           <br>
           <br>
         `,


### PR DESCRIPTION
Fix a typo in the locale example code (import `deLocale` instead of `de`).
Fix a typo in datepicker description.

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [ ] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
